### PR TITLE
refactor: type stat cards

### DIFF
--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -2,15 +2,24 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { useTimerStore } from '@/store/timerStore';
 import { TrendingUp, Target, Calendar, Trophy } from 'lucide-react';
 import { motion } from 'framer-motion';
+import type React from 'react';
 
 interface StatsPanelProps {
   className?: string;
 }
 
+interface StatCard {
+  title: string;
+  value: number;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+  description: string;
+}
+
 export function StatsPanel({ className = '' }: StatsPanelProps) {
   const { stats, completedPomodoros } = useTimerStore();
 
-  const statCards = [
+  const statCards: StatCard[] = [
     {
       title: 'Today',
       value: stats.todayPomodoros,


### PR DESCRIPTION
## Summary
- define dedicated StatCard interface with typed icon
- apply interface to statCards for stronger type inference

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 11 problems (4 errors, 7 warnings))
- `npx eslint src/components/StatsPanel.tsx`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a854d3536483228c15a9cf358f888f